### PR TITLE
Bugfixes: FatalTrhowable error and Work start Column

### DIFF
--- a/src/Wrapper/SheetWrapper.php
+++ b/src/Wrapper/SheetWrapper.php
@@ -3,7 +3,7 @@
 namespace MewesK\TwigSpreadsheetBundle\Wrapper;
 
 use PhpOffice\PhpSpreadsheet\Exception;
-use PhpOffice\PhpSpreadsheet\Worksheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\ColumnDimension;
 use PhpOffice\PhpSpreadsheet\Worksheet\RowDimension;
 

--- a/src/Wrapper/SheetWrapper.php
+++ b/src/Wrapper/SheetWrapper.php
@@ -15,7 +15,7 @@ class SheetWrapper extends BaseWrapper
     /**
      * @var int
      */
-    const COLUMN_DEFAULT = 0;
+    const COLUMN_DEFAULT = 1;
     /**
      * @var int
      */


### PR DESCRIPTION
This pull request fixes two problems:

1) The FatalTrhowable error: Type error: Return value of MewesK\TwigSpreadsheetBundle\Wrapper\SheetWrapper::getObject() must be an instance of PhpOffice\PhpSpreadsheet\Worksheet, instance of PhpOffice\PhpSpreadsheet\Worksheet\Worksheet returned

2) First data apearing in Column Z instead of A