### PR TITLE
Bugfix

### DIFF
--- a/src/Wrapper/CellWrapper.php
+++ b/src/Wrapper/CellWrapper.php
@@ -2,7 +2,8 @@
 
 namespace MewesK\TwigSpreadsheetBundle\Wrapper;
 
-use PhpOffice\PhpSpreadsheet\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 
 /**
  * Class CellWrapper.
@@ -121,7 +122,7 @@ class CellWrapper extends BaseWrapper
             ],
             'merge' => function ($value) {
                 if (is_int($value)) {
-                    $value = Cell::stringFromColumnIndex($value).$this->sheetWrapper->getRow();
+                    $value = Coordinate::stringFromColumnIndex($value).$this->sheetWrapper->getRow();
                 }
                 $this->sheetWrapper->getObject()->mergeCells(sprintf('%s:%s', $this->object->getCoordinate(), $value));
             },

--- a/src/Wrapper/SheetWrapper.php
+++ b/src/Wrapper/SheetWrapper.php
@@ -3,7 +3,7 @@
 namespace MewesK\TwigSpreadsheetBundle\Wrapper;
 
 use PhpOffice\PhpSpreadsheet\Exception;
-use PhpOffice\PhpSpreadsheet\Worksheet;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\ColumnDimension;
 use PhpOffice\PhpSpreadsheet\Worksheet\RowDimension;
 

--- a/src/Wrapper/SheetWrapper.php
+++ b/src/Wrapper/SheetWrapper.php
@@ -15,7 +15,7 @@ class SheetWrapper extends BaseWrapper
     /**
      * @var int
      */
-    const COLUMN_DEFAULT = 0;
+    const COLUMN_DEFAULT = 1;
     /**
      * @var int
      */


### PR DESCRIPTION
This pull request fixes three problems:

1) The FatalTrhowable error: Type error: Return value of MewesK\TwigSpreadsheetBundle\Wrapper\SheetWrapper::getObject() must be an instance of PhpOffice\PhpSpreadsheet\Worksheet, instance of PhpOffice\PhpSpreadsheet\Worksheet\Worksheet returned

2) First data appearing in Column Z instead of A

3) Attempted to call an undefined method named "stringFromColumnIndex" of class "PhpOffice\PhpSpreadsheet\Cell"

