### PR TITLE
Use phpspreadsheet version 1 stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "symfony/framework-bundle": "~3.2|~4.0",
         "twig/twig": "~2.0",
-        "phpoffice/phpspreadsheet": "1.0.0-beta2"
+        "phpoffice/phpspreadsheet": "^1@dev"
     },
     "require-dev": {
         "symfony/symfony": "~3.2|~4.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "symfony/framework-bundle": "~3.2|~4.0",
         "twig/twig": "~2.0",
-        "phpoffice/phpspreadsheet": "^1@dev"
+        "phpoffice/phpspreadsheet": "^1"
     },
     "require-dev": {
         "symfony/symfony": "~3.2|~4.0",


### PR DESCRIPTION
No need to use 1.0 beta2. It's ok to use version 1 now.