### PR TITLE
Upgrade phpoffice/phpspreadsheet from ~1.3.1 to ^1.5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.0",
         "symfony/framework-bundle": "~3.2|~4.0",
         "twig/twig": "~2.0",
-        "phpoffice/phpspreadsheet": "~1.3.1"
+        "phpoffice/phpspreadsheet": "^1.5.2"
     },
     "require-dev": {
         "symfony/symfony": "~3.2|~4.0",


### PR DESCRIPTION
The version of `phpoffice/phpspreadsheet` should be bumped to fix [CVE-2018-19277](https://nvd.nist.gov/vuln/detail/CVE-2018-19277).

Fixes #18.